### PR TITLE
Fixed Single VC MenuView CenterItem bug

### DIFF
--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -192,11 +192,11 @@ class MenuView: UIScrollView {
     private func adjustmentContentInsetIfNeeded() {
         switch options.menuDisplayMode {
         case .FlexibleItemWidth(let centerItem, _):
-            if !centerItem {
+            if centerItem != true {
                 return
             }
         case .FixedItemWidth(_, let centerItem, _):
-            if !centerItem {
+            if centerItem != true{
                 return
             }
         case .SegmentedControl:
@@ -216,12 +216,12 @@ class MenuView: UIScrollView {
     private func targetContentOffsetX(#nextIndex: Int) -> CGFloat {
         switch options.menuDisplayMode {
         case .FlexibleItemWidth(let centerItem, _):
-            if !centerItem {
+            if centerItem != true {
                 return contentOffsetXForCurrentPage(nextIndex: nextIndex)
             }
             return centerOfScreenWidth(nextIndex: nextIndex)
         case .FixedItemWidth(_, let centerItem, _):
-            if !centerItem {
+            if centerItem != true {
                 return contentOffsetXForCurrentPage(nextIndex: nextIndex)
             }
             return centerOfScreenWidth(nextIndex: nextIndex)


### PR DESCRIPTION
The MenuView would slide to the left because `targetContentOffsetX` would return early. This was caused by the `if statement` evaluating to false even though `centerItem` was set to `true`. Changing the `!` prefix notation to a simple statement solved the issue.

![screen shot 2015-08-17 at 11 12 30](https://cloud.githubusercontent.com/assets/6463146/9301892/4d3c6838-44d2-11e5-9521-597340b2649c.png)

![screen shot 2015-08-17 at 11 11 27](https://cloud.githubusercontent.com/assets/6463146/9301895/518f2420-44d2-11e5-9e97-dd5dc867995b.png)
