### PR TITLE
Addition of standalone Menuview

### DIFF
--- a/Pod/Classes/MenuItemView.swift
+++ b/Pod/Classes/MenuItemView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class MenuItemView: UIView {
+public class MenuItemView: UIView {
     
     private var options: PagingMenuOptions!
     private var title: String!
@@ -29,7 +29,7 @@ class MenuItemView: UIView {
         layoutLabel()
     }
     
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
     

--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class MenuView: UIScrollView {
+public class MenuView: UIScrollView {
     
-    internal var menuItemViews = [MenuItemView]()
+    public var menuItemViews = [MenuItemView]()
     private var sortedMenuItemViews = [MenuItemView]()
     private var options: PagingMenuOptions!
     private var contentView: UIView!
@@ -20,10 +20,11 @@ class MenuView: UIScrollView {
     
     // MARK: - Lifecycle
     
-    internal init(menuItemTitles: [String], options: PagingMenuOptions) {
+    public init(menuItemTitles: [String], options: PagingMenuOptions) {
         super.init(frame: CGRectZero)
         
         self.options = options
+		options.menuItemCount = menuItemTitles.count
         
         setupScrollView()
         constructContentView()
@@ -34,19 +35,20 @@ class MenuView: UIScrollView {
         constructUnderlineViewIfNeeded()
     }
     
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
     
-    override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
-        
+		
         adjustmentContentInsetIfNeeded()
     }
-    
+	
     // MARK: - Public method
     
-    internal func moveToMenu(page page: Int, animated: Bool) {
+    public func moveToMenu(page page: Int, animated: Bool) {
+		
         let duration = animated ? options.animationDuration : 0
         currentPage = page
         

--- a/Pod/Classes/PagingMenuController.swift
+++ b/Pod/Classes/PagingMenuController.swift
@@ -31,7 +31,7 @@ public class PagingMenuController: UIViewController, UIScrollViewDelegate {
         }
     }
     private var currentPage: Int = 0
-    private var currentViewController: UIViewController!
+    public var currentViewController: UIViewController!
     private var menuItemTitles: [String] {
         get {
             return pagingViewControllers.map {
@@ -86,13 +86,14 @@ public class PagingMenuController: UIViewController, UIScrollViewDelegate {
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
-    public override func viewWillAppear(animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        moveToMenuPage(currentPage, animated: false)
-    }
-    
+	
+	public override func viewDidAppear(animated: Bool) {
+		super.viewDidAppear(animated)
+		
+		
+		moveToMenuPage(currentPage, animated: false)
+	}
+	
     override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
@@ -152,7 +153,8 @@ public class PagingMenuController: UIViewController, UIScrollViewDelegate {
 
         currentPosition = currentPagingViewPosition()
         currentViewController = pagingViewControllers[currentPage]
-    }
+		
+	}
     
     public func rebuild(viewControllers: [UIViewController], options: PagingMenuOptions) {
         setup(viewControllers: viewControllers, options: options)

--- a/Pod/Classes/PagingMenuOptions.swift
+++ b/Pod/Classes/PagingMenuOptions.swift
@@ -23,12 +23,13 @@ public class PagingMenuOptions {
     public var animationDuration: NSTimeInterval = 0.3
     public var menuDisplayMode = MenuDisplayMode.Standard(widthMode: PagingMenuOptions.MenuItemWidthMode.Flexible, centerItem: false, scrollingMode: PagingMenuOptions.MenuScrollingMode.PagingEnabled)
     public var menuItemMode = MenuItemMode.Underline(height: 3, color: UIColor.blueColor(), horizontalPadding: 0, verticalPadding: 0)
-    internal var menuItemCount = 0
-    internal let minumumSupportedViewCount = 1
+    public var menuItemCount = 0
+    public let minumumSupportedViewCount = 1
     
     public enum MenuPosition {
         case Top
         case Bottom
+		case Standalone
     }
     
     public enum MenuScrollingMode {


### PR DESCRIPTION
I have a unique requirement to split off the MenuView from the PagingMenuController and set it as the header view within a tableview (so it sticks). I modified the code to 1) expose private vars 2) to allow for standalone layout of the menu. Here is how I'm using it... 

```swift
func initializeMenu() {
		
		pagingMenuOptions = PagingMenuOptions()
		pagingMenuOptions.menuItemMargin = 15.0
		pagingMenuOptions.menuHeight = menuHeight
		pagingMenuOptions.font = UIFont(name: "HelveticaNeue", size: 14)!
	    pagingMenuOptions.menuDisplayMode = PagingMenuOptions.MenuDisplayMode.SegmentedControl
		
		pagingMenuOptions.menuItemMode = PagingMenuOptions.MenuItemMode.Underline(height: CGFloat(2.0), color: Color.magenta, horizontalPadding: CGFloat(2.0), verticalPadding: CGFloat(0.0))
		pagingMenuOptions.selectedTextColor = Color.darkGray
		pagingMenuOptions.menuPosition = PagingMenuOptions.MenuPosition.Standalone
		
		var titles:[String] = [String]()
		...
		
		profileScrollMenuView = ProfileScrollMenuView(menuItemTitles: titles, options: pagingMenuOptions)
				
	}
	
	func initializePagingController() {
		
		viewControllers = [UIViewController]()
		...
		pagingMenuController = PagingMenuController(viewControllers: viewControllers, options: pagingMenuOptions)
		pagingMenuController?.menuView = profileScrollMenuView.menuView
		pagingMenuController?.delegate = self
		
		self.addChildViewController(pagingMenuController!)
		pagingMenuController!.didMoveToParentViewController(self)
	}

// Profile Scroll Menu wrapper
class ProfileScrollMenuView: UIView {
	
	var menuView:MenuView!
	
	var options:PagingMenuOptions!
	var menuTitles:[String] = [String]()
	
	var delegate:ProfileScrollMenuViewDelegate?
	var hasGestureHandlers:Bool = false
	
	var topLineView:UIView!
	var bottomLineView:UIView!
	
	private var currentPage: Int = 0
	private var previousIndex: Int {
		if case .Infinite(_) = options.menuDisplayMode {
			return currentPage - 1 < 0 ? options.menuItemCount - 1 : currentPage - 1
		}
		return currentPage - 1
	}
	private var nextIndex: Int {
		if case .Infinite(_) = options.menuDisplayMode {
			return currentPage + 1 > options.menuItemCount - 1 ? 0 : currentPage + 1
		}
		return currentPage + 1
	}
	
	
	init(menuItemTitles: [String], options:PagingMenuOptions) {
		super.init(frame: CGRectZero)
		
		menuTitles = menuItemTitles
		self.options = options
		self.options.menuItemCount = menuItemTitles.count
		
		setup()
	}
	
	
	required init?(coder aDecoder: NSCoder) {
		super.init(coder: aDecoder)
	}
	
	
	
	func setup() {
	
		menuView = MenuView(menuItemTitles: menuTitles, options: options)
		self.addSubview(menuView)
		
	}
	
	override func layoutSubviews() {
		super.layoutSubviews()
		
		layoutMenuView()
		
		topLineView = UIView(frame: CGRectMake(0, 0, self.frame.width, 0.5))
		topLineView.backgroundColor = Color.separator
		self.addSubview(topLineView)
		
		bottomLineView = UIView(frame: CGRectMake(0, self.frame.height-0.5, self.frame.width, 0.5))
		bottomLineView.backgroundColor = Color.separator
		self.addSubview(bottomLineView)
		
	}
	
	private func layoutMenuView() {
		let viewsDictionary = ["menuView": menuView ]
		let metrics = ["height": options.menuHeight]
		let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[menuView]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: viewsDictionary)
		let verticalConstraints: [NSLayoutConstraint] =  NSLayoutConstraint.constraintsWithVisualFormat("V:|[menuView(height)]", options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: viewsDictionary)
		
		NSLayoutConstraint.activateConstraints(horizontalConstraints + verticalConstraints)
		
		menuView.setNeedsLayout()
		menuView.layoutIfNeeded()
	}
	
}
``` 