### PR TITLE
Added option for inserting an image as divider between two menu item views

### DIFF
--- a/Pod/Classes/MenuItemView.swift
+++ b/Pod/Classes/MenuItemView.swift
@@ -18,19 +18,29 @@ public class MenuItemView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
+    public private(set) var dividerImage: UIImageView!
     private var options: PagingMenuOptions!
     private var widthLabelConstraint: NSLayoutConstraint!
     
     // MARK: - Lifecycle
     
-    internal init(title: String, options: PagingMenuOptions) {
+    internal init(title: String, options: PagingMenuOptions, addDivider: Bool) {
         super.init(frame: .zero)
         
         self.options = options
         
         setupView()
         setupLabel(title: title)
+
+        if options.menuItemDividerImage != nil && addDivider {
+            setupDivider()
+        }
+
         layoutLabel()
+
+        if options.menuItemDividerImage != nil && addDivider {
+            layoutDivider()
+        }
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -91,6 +101,12 @@ public class MenuItemView: UIView {
         addSubview(titleLabel)
     }
     
+    private func setupDivider() {
+        dividerImage = UIImageView(image: options.menuItemDividerImage)
+        dividerImage.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(dividerImage)
+    }
+
     private func layoutLabel() {
         let viewsDictionary = ["label": titleLabel]
         
@@ -105,6 +121,13 @@ public class MenuItemView: UIView {
         widthLabelConstraint.active = true
     }
     
+    private func layoutDivider() {
+        var constraint = NSLayoutConstraint(item: dividerImage, attribute: NSLayoutAttribute.CenterY, relatedBy: NSLayoutRelation.Equal, toItem: self, attribute: NSLayoutAttribute.CenterY, multiplier: 1.0, constant: 1.0)
+        addConstraint(constraint)
+        constraint = NSLayoutConstraint(item: dividerImage, attribute: NSLayoutAttribute.Right, relatedBy: NSLayoutRelation.Equal, toItem: self, attribute: NSLayoutAttribute.Right, multiplier: 1.0, constant: 0.0)
+        addConstraint(constraint)
+    }
+
     // MARK: - Size calculator
     
     private func calculateLableSize(size size: CGSize = UIApplication.sharedApplication().keyWindow!.bounds.size) -> CGSize {

--- a/Pod/Classes/MenuItemView.swift
+++ b/Pod/Classes/MenuItemView.swift
@@ -31,14 +31,10 @@ public class MenuItemView: UIView {
         
         setupView()
         setupLabel(title: title)
-
-        if options.menuItemDividerImage != nil && addDivider {
-            setupDivider()
-        }
-
         layoutLabel()
 
         if options.menuItemDividerImage != nil && addDivider {
+            setupDivider()
             layoutDivider()
         }
     }
@@ -122,10 +118,10 @@ public class MenuItemView: UIView {
     }
     
     private func layoutDivider() {
-        var constraint = NSLayoutConstraint(item: dividerImage, attribute: NSLayoutAttribute.CenterY, relatedBy: NSLayoutRelation.Equal, toItem: self, attribute: NSLayoutAttribute.CenterY, multiplier: 1.0, constant: 1.0)
-        addConstraint(constraint)
-        constraint = NSLayoutConstraint(item: dividerImage, attribute: NSLayoutAttribute.Right, relatedBy: NSLayoutRelation.Equal, toItem: self, attribute: NSLayoutAttribute.Right, multiplier: 1.0, constant: 0.0)
-        addConstraint(constraint)
+        let centerConstraint = NSLayoutConstraint(item: dividerImage, attribute: NSLayoutAttribute.CenterY, relatedBy: NSLayoutRelation.Equal, toItem: self, attribute: NSLayoutAttribute.CenterY, multiplier: 1.0, constant: 1.0)
+        addConstraint(centerConstraint)
+        let rightConstraint = NSLayoutConstraint(item: dividerImage, attribute: NSLayoutAttribute.Right, relatedBy: NSLayoutRelation.Equal, toItem: self, attribute: NSLayoutAttribute.Right, multiplier: 1.0, constant: 0.0)
+        addConstraint(rightConstraint)
     }
 
     // MARK: - Size calculator

--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -143,7 +143,8 @@ public class MenuView: UIScrollView {
     
     private func constructMenuItemViews(titles titles: [String]) {
         for i in 0..<options.menuItemCount {
-            let menuItemView = MenuItemView(title: titles[i], options: options)
+            let addDivider = i < options.menuItemCount - 1
+            let menuItemView = MenuItemView(title: titles[i], options: options, addDivider: addDivider)
             menuItemView.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview(menuItemView)
             

--- a/Pod/Classes/PagingMenuOptions.swift
+++ b/Pod/Classes/PagingMenuOptions.swift
@@ -20,6 +20,7 @@ public class PagingMenuOptions {
     public var menuPosition: MenuPosition = .Top
     public var menuHeight: CGFloat = 50
     public var menuItemMargin: CGFloat = 20
+    public var menuItemDividerImage: UIImage! = nil
     public var animationDuration: NSTimeInterval = 0.3
     public var deceleratingRate: CGFloat = UIScrollViewDecelerationRateNormal
     public var menuDisplayMode = MenuDisplayMode.Standard(widthMode: PagingMenuOptions.MenuItemWidthMode.Flexible, centerItem: false, scrollingMode: PagingMenuOptions.MenuScrollingMode.PagingEnabled)

--- a/Pod/Classes/PagingMenuOptions.swift
+++ b/Pod/Classes/PagingMenuOptions.swift
@@ -20,7 +20,7 @@ public class PagingMenuOptions {
     public var menuPosition: MenuPosition = .Top
     public var menuHeight: CGFloat = 50
     public var menuItemMargin: CGFloat = 20
-    public var menuItemDividerImage: UIImage! = nil
+    public var menuItemDividerImage: UIImage? = nil
     public var animationDuration: NSTimeInterval = 0.3
     public var deceleratingRate: CGFloat = UIScrollViewDecelerationRateNormal
     public var menuDisplayMode = MenuDisplayMode.Standard(widthMode: PagingMenuOptions.MenuItemWidthMode.Flexible, centerItem: false, scrollingMode: PagingMenuOptions.MenuScrollingMode.PagingEnabled)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ menuHeight: CGFloat
 ```Swift
 menuItemMargin: CGFloat
 ```
+* divider image to display right aligned in each menu item
+```Swift
+menuItemDividerImage: UIImage
+```
 * duration for menu item view animation
 ```Swift
 animationDuration: NSTimeInterval


### PR DESCRIPTION
Fixes # .

Added option for inserting and image as divider between two menu item views.

The divider image is right aligned and vertically centered within each
menu item view. The divider image is added to all menu item views except
for the last one.

<img width="423" alt="divider screenshot" src="https://cloud.githubusercontent.com/assets/2119132/14378370/d03f10f4-fd74-11e5-8804-8492dc2392f5.png">
