### PR TITLE
add a option to disable selected menu item centering

### DIFF
--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -70,7 +70,9 @@ public class MenuView: UIScrollView {
             guard let _ = self else { return }
             
             self!.focusMenuItem()
-            self!.positionMenuItemViews()
+            if self!.options.menuSelectedItemCenter {
+                self!.positionMenuItemViews()
+            }
         }) { [weak self] (_) in
             guard let _ = self else { return }
             
@@ -78,7 +80,9 @@ public class MenuView: UIScrollView {
             if case .Infinite = self!.options.menuDisplayMode {
                 self!.relayoutMenuItemViews()
             }
-            self!.positionMenuItemViews()
+            if self!.options.menuSelectedItemCenter {
+                self!.positionMenuItemViews()
+            }
             self!.setNeedsLayout()
             self!.layoutIfNeeded()
             

--- a/Pod/Classes/PagingMenuOptions.swift
+++ b/Pod/Classes/PagingMenuOptions.swift
@@ -23,6 +23,7 @@ public class PagingMenuOptions {
     public var animationDuration: NSTimeInterval = 0.3
     public var deceleratingRate: CGFloat = UIScrollViewDecelerationRateNormal
     public var menuDisplayMode = MenuDisplayMode.Standard(widthMode: PagingMenuOptions.MenuItemWidthMode.Flexible, centerItem: false, scrollingMode: PagingMenuOptions.MenuScrollingMode.PagingEnabled)
+    public var menuSelectedItemCenter = true
     public var menuItemMode = MenuItemMode.Underline(height: 3, color: UIColor.blueColor(), horizontalPadding: 0, verticalPadding: 0)
     public var lazyLoadingPage: LazyLoadingPage = .Three
     internal var menuItemCount = 0


### PR DESCRIPTION
add a option to disable selected menu item center positioning behavior. 
if we have only two menu item, this behavior looks wired (in my opinion)