### PR TITLE
Add current menu info to menu view

### DIFF
--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -97,7 +97,7 @@ public class MenuView: UIScrollView {
     
     // MARK: - Public method
     
-    internal func moveToMenu(page page: Int, animated: Bool) {
+    internal func moveToMenu(page: Int, animated: Bool) {
         let duration = animated ? options.animationDuration : 0
         currentPage = page
         

--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -11,9 +11,10 @@ import UIKit
 public class MenuView: UIScrollView {
     
     public private(set) var menuItemViews = [MenuItemView]()
+    public private(set) var currentPage: Int = 0
+    public private(set) var currentMenuItemView: MenuItemView!
     private var sortedMenuItemViews = [MenuItemView]()
     private var options: PagingMenuOptions!
-    private var currentPage: Int = 0
     
     private let contentView: UIView = {
         let view = UIView(frame: .zero)
@@ -303,7 +304,12 @@ public class MenuView: UIScrollView {
         let selected: (MenuItemView) -> Bool = { self.menuItemViews.indexOf($0) == self.currentPage }
         
         // make selected item focused
-        menuItemViews.forEach { $0.selected = selected($0) }
+        menuItemViews.forEach {
+            $0.selected = selected($0)
+            if $0.selected {
+                self.currentMenuItemView = $0
+            }
+        }
 
         // make selected item foreground
         sortedMenuItemViews.forEach { $0.layer.zPosition = selected($0) ? 0 : -1 }

--- a/Pod/Classes/PagingMenuController.swift
+++ b/Pod/Classes/PagingMenuController.swift
@@ -130,7 +130,7 @@ public class PagingMenuController: UIViewController, UIScrollViewDelegate {
         super.viewWillAppear(animated)
         
         // position properly for Infinite mode
-        menuView?.moveToMenu(page: currentPage, animated: false)
+        menuView?.moveToMenu(currentPage, animated: false)
     }
     
     override public func viewDidLayoutSubviews() {
@@ -160,7 +160,7 @@ public class PagingMenuController: UIViewController, UIScrollViewDelegate {
                 // reset selected menu item view position
                 switch self!.options.menuDisplayMode {
                 case .Standard, .Infinite:
-                    self!.menuView.moveToMenu(page: self!.currentPage, animated: true)
+                    self!.menuView.moveToMenu(self!.currentPage, animated: true)
                 default: break
                 }
                 }, completion: nil)
@@ -203,7 +203,7 @@ public class PagingMenuController: UIViewController, UIScrollViewDelegate {
         delegate?.willMoveToPageMenuController?(currentViewController, previousMenuController: previousViewController)
         
         currentPage = page
-        menuView.moveToMenu(page: currentPage, animated: animated)
+        menuView.moveToMenu(currentPage, animated: animated)
         
         // hide paging views if it's moving to far away
         hidePagingViewsIfNeeded(previousPage)
@@ -248,7 +248,7 @@ public class PagingMenuController: UIViewController, UIScrollViewDelegate {
         delegate?.willMoveToPageMenuController?(currentViewController, previousMenuController: previousViewController)
         
         currentPage = nextPage
-        menuView.moveToMenu(page: currentPage, animated: true)
+        menuView.moveToMenu(currentPage, animated: true)
         if let currentView = currentViewController.view {
             contentScrollView.contentOffset.x = currentView.frame.minX
         }


### PR DESCRIPTION
Changes proposed in this pull request:
Properties below are now public read only
- `currentPage`
- `currentMenuItemView`
