### PR TITLE
Fix a method name typo

### DIFF
--- a/Pod/Classes/MenuItemView.swift
+++ b/Pod/Classes/MenuItemView.swift
@@ -38,7 +38,7 @@ public class MenuItemView: UIView {
                 titleLabel.font = selected ? options.selectedFont : options.font
                 
                 // adjust label width if needed
-                let labelSize = calculateLableSize()
+                let labelSize = calculateLabelSize()
                 widthConstraint.constant = labelSize.width
             case .Image: break
             }
@@ -126,7 +126,7 @@ public class MenuItemView: UIView {
         // set width manually to support ratotaion
         switch (options.menuDisplayMode, options.menuItemViewContent) {
         case (.SegmentedControl, .Text):
-            let labelSize = calculateLableSize(size)
+            let labelSize = calculateLabelSize(size)
             widthConstraint.constant = labelSize.width
         case (.SegmentedControl, .Image):
             widthConstraint.constant = size.width / CGFloat(options.menuItemCount)
@@ -166,7 +166,7 @@ public class MenuItemView: UIView {
     private func layoutLabel() {
         let viewsDictionary = ["label": titleLabel]
         
-        let labelSize = calculateLableSize()
+        let labelSize = calculateLabelSize()
 
         let horizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[label]|", options: [], metrics: nil, views: viewsDictionary)
         let verticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[label]|", options: [], metrics: nil, views: viewsDictionary)
@@ -204,7 +204,7 @@ public class MenuItemView: UIView {
 
     // MARK: - Size calculator
     
-    private func calculateLableSize(size: CGSize = UIApplication.sharedApplication().keyWindow!.bounds.size) -> CGSize {
+    private func calculateLabelSize(size: CGSize = UIApplication.sharedApplication().keyWindow!.bounds.size) -> CGSize {
         guard let _ = titleLabel.text else { return .zero }
         
         let itemWidth: CGFloat


### PR DESCRIPTION
I found a method name typo.

```
func calculateLableSize()
```
↓
```
func calculateLabelSize()
```

'Label'.