### PR TITLE
Fix warning error in iOS 8.1

### DIFF
--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -67,7 +67,7 @@ public class MenuView: UIScrollView {
     
     // MARK: - Lifecycle
     internal init(menuOptions: MenuViewCustomizable) {
-        super.init(frame: .zero)
+        super.init(frame: CGRectMake(0, 0, 0, menuOptions.height))
         
         self.menuOptions = menuOptions
         


### PR DESCRIPTION
Fixes #230  .

Changes proposed in this pull request:
- fix warning error(Unable to simultaneously satisfy constraints.) in iOS 8.1

I have the same problem #230, so I have fixed it !

