### PR TITLE
Avoid out of bounds on UIScrollView

### DIFF
--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -164,6 +164,7 @@ open class MenuView: UIScrollView {
         showsVerticalScrollIndicator = false
         bounces = menuViewBounces
         isScrollEnabled = menuViewScrollEnabled
+        isDirectionalLockEnabled = true
         decelerationRate = menuOptions.deceleratingRate
         scrollsToTop = false
         translatesAutoresizingMaskIntoConstraints = false

--- a/Pod/Classes/PagingViewController.swift
+++ b/Pod/Classes/PagingViewController.swift
@@ -15,6 +15,7 @@ open class PagingViewController: UIViewController {
     
     internal let contentScrollView: UIScrollView = {
         $0.isPagingEnabled = true
+        $0.isDirectionalLockEnabled = true
         $0.showsHorizontalScrollIndicator = false
         $0.showsVerticalScrollIndicator = false
         $0.scrollsToTop = false


### PR DESCRIPTION
Fixes #255 .

Changes proposed in this pull request:
- Set `isDirectionalLockEnabled` to true by default

