### PR TITLE
Add scrolling delegate functionality to allow callbacks for scroll start/end

### DIFF
--- a/PagingMenuController.xcodeproj/project.pbxproj
+++ b/PagingMenuController.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		659FC0FB1E152C66003DC488 /* PagingMenuScrollEventsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659FC0FA1E152C66003DC488 /* PagingMenuScrollEventsDelegate.swift */; };
+		659FC0FD1E152C96003DC488 /* PagingMenuScrollEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659FC0FC1E152C96003DC488 /* PagingMenuScrollEvents.swift */; };
 		EC202B521D0C54D100D527D2 /* MenuItemViewCustomizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC202B471D0C54D100D527D2 /* MenuItemViewCustomizable.swift */; };
 		EC202B531D0C54D100D527D2 /* MenuViewCustomizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC202B481D0C54D100D527D2 /* MenuViewCustomizable.swift */; };
 		EC202B541D0C54D100D527D2 /* Pagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC202B491D0C54D100D527D2 /* Pagable.swift */; };
@@ -19,6 +21,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		659FC0FA1E152C66003DC488 /* PagingMenuScrollEventsDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingMenuScrollEventsDelegate.swift; sourceTree = "<group>"; };
+		659FC0FC1E152C96003DC488 /* PagingMenuScrollEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingMenuScrollEvents.swift; sourceTree = "<group>"; };
 		EC202B471D0C54D100D527D2 /* MenuItemViewCustomizable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuItemViewCustomizable.swift; sourceTree = "<group>"; };
 		EC202B481D0C54D100D527D2 /* MenuViewCustomizable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuViewCustomizable.swift; sourceTree = "<group>"; };
 		EC202B491D0C54D100D527D2 /* Pagable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pagable.swift; sourceTree = "<group>"; };
@@ -50,6 +54,7 @@
 				EC202B481D0C54D100D527D2 /* MenuViewCustomizable.swift */,
 				EC202B491D0C54D100D527D2 /* Pagable.swift */,
 				EC202B4C1D0C54D100D527D2 /* PagingMenuControllerCustomizable.swift */,
+				659FC0FA1E152C66003DC488 /* PagingMenuScrollEventsDelegate.swift */,
 			);
 			name = Protocols;
 			path = Pod/Classes/Protocols;
@@ -80,6 +85,7 @@
 				ECE530851B6DEB68001CF201 /* PagingMenuController.swift */,
 				ECA210891D054879006AA684 /* PagingViewController.swift */,
 				ECE5306C1B6DEB18001CF201 /* PagingMenuController.h */,
+				659FC0FC1E152C96003DC488 /* PagingMenuScrollEvents.swift */,
 				ECE5306A1B6DEB18001CF201 /* Supporting Files */,
 			);
 			path = PagingMenuController;
@@ -173,6 +179,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				EC202B541D0C54D100D527D2 /* Pagable.swift in Sources */,
+				659FC0FB1E152C66003DC488 /* PagingMenuScrollEventsDelegate.swift in Sources */,
+				659FC0FD1E152C96003DC488 /* PagingMenuScrollEvents.swift in Sources */,
 				EC202B531D0C54D100D527D2 /* MenuViewCustomizable.swift in Sources */,
 				EC202B521D0C54D100D527D2 /* MenuItemViewCustomizable.swift in Sources */,
 				ECA2108A1D054879006AA684 /* PagingViewController.swift in Sources */,

--- a/PagingMenuController/PagingMenuScrollEvents.swift
+++ b/PagingMenuController/PagingMenuScrollEvents.swift
@@ -1,0 +1,65 @@
+//
+//  PagingMenuScrollEvents.swift
+//  PagingMenuController
+//
+//  Created by Solomon Sammy on 29/Dec/2016.
+//  Copyright © 2016 kitasuke. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Use like:
+ *   let pagingMenuScrollEvents = PagingMenuScrollEvents.sharedInstance
+ *   pagingMenuScrollEvents.addScrollEventsDelegate(self.appDelegate.driveController)
+ *
+ *   ...
+ *
+ *   pagingMenuScrollEvents.addScrollEventsDelegate(this)
+ *
+ *   ...
+ */
+
+public class PagingMenuScrollEvents {
+
+    // Can't init is singleton
+    private init() {
+    }
+
+    //MARK: Shared Instance
+
+    public static let sharedInstance: PagingMenuScrollEvents = PagingMenuScrollEvents()
+    
+    //MARK: Local Variable
+    public var scrollEventsDelegates = [PagingMenuScrollEventsDelegate]()
+
+    /**
+     * Add a delegate to the list of delgates to be informed of scrolling events.
+     *
+     *  - parameter delegate: the callback to be invoked when scrolling is started or stopped.
+     */
+    public func addScrollEventsDelegate(_ delegate: PagingMenuScrollEventsDelegate) {
+        scrollEventsDelegates.append(delegate)
+    }
+
+    /**
+     * Remove a delegate from the list of delgates to be informed of scrolling events.
+     *
+     *  - parameter delegate: the callback to be invoked when scrolling is started or stopped.
+     */
+    public func removeScrollEventsDelegate(_ delegate: PagingMenuScrollEventsDelegate) {
+        for (index, value) in scrollEventsDelegates.enumerated() {
+            if (value === delegate) {
+                scrollEventsDelegates.remove(at: index)
+            }
+        }
+    }
+
+    /**
+     * Remove all delegates from the list of delgates to be informed of scrolling events.
+     */
+    public func removeAllScrollEventsDelegates() {
+        scrollEventsDelegates.removeAll()
+    }
+
+}

--- a/Pod/Classes/PagingMenuController.swift
+++ b/Pod/Classes/PagingMenuController.swift
@@ -321,8 +321,26 @@ extension PagingMenuController: UIScrollViewDelegate {
         
         move(toPage: nextPage)
     }
-    
+
+    public func scrollViewWillBeginDragging(scrollView: UIScrollView) {
+        // get a reference to the singleton's array of delegates
+        let scrollEventsDelegates = PagingMenuScrollEvents.sharedInstance.scrollEventsDelegates
+
+        // inform all who wish to know
+        for delegate in scrollEventsDelegates {
+            delegate.scrollingStarted()
+        }
+    }
+
     public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        // get a reference to the singleton's array of delegates
+        let scrollEventsDelegates = PagingMenuScrollEvents.sharedInstance.scrollEventsDelegates
+
+        // inform all who wish to know
+        for delegate in scrollEventsDelegates {
+            delegate.scrollingEnded()
+        }
+        
         switch (scrollView, decelerate) {
         case (let scrollView, false) where scrollView.isEqual(menuView): break
         default: return

--- a/Pod/Classes/Protocols/PagingMenuScrollEventsDelegate.swift
+++ b/Pod/Classes/Protocols/PagingMenuScrollEventsDelegate.swift
@@ -1,0 +1,24 @@
+//
+//  PagingMenuScrollEventsDelegate.swift
+//  PagingMenuController
+//
+//  Created by Solomon Sammy on 29/Dec/2016.
+//  Copyright © 2016 kitasuke. All rights reserved.
+//
+
+import Foundation
+
+public protocol PagingMenuScrollEventsDelegate: class {
+
+    /**
+     * PagingMenuController calls this when scrolling has started.
+     * Use it to disable background tasks when scrolling.
+     */
+    func scrollingStarted()
+
+    /**
+     * PagingMenuController calls this when scrolling has ended.
+     * Use it to enable background tasks when scrolling.
+     */
+    func scrollingEnded()
+}


### PR DESCRIPTION
I needed to be able to detect when scrolling started and ended in my application, so that expensive background tasks could be disabled whilst scrolling was happening. Otherwise the scrolling experienced was jerky and teared in some situations, especially on lower spec phones.

I'm not very experienced with iOS and XCode, so it might be I've made some school-boy mistakes: let me know and I'll try to fix!

