### PR TITLE
Disable auto-select by swiping MenuItem on Standard mode

### DIFF
--- a/Pod/Classes/PagingMenuController.swift
+++ b/Pod/Classes/PagingMenuController.swift
@@ -319,7 +319,10 @@ extension PagingMenuController: UIScrollViewDelegate {
         case let (scrollView, pagingViewController?, _) where scrollView.isEqual(pagingViewController.contentScrollView):
             nextPage = nextPageFromCurrentPosition
         case let (scrollView, _, menuView?) where scrollView.isEqual(menuView):
-            nextPage = nextPageFromCurrentPoint
+            switch menuOptions!.displayMode {
+            case .standard(_, let centerItem, _) where !centerItem: return
+            default: nextPage = nextPageFromCurrentPoint
+            }
         default: return
         }
         

--- a/Pod/Classes/PagingMenuController.swift
+++ b/Pod/Classes/PagingMenuController.swift
@@ -313,16 +313,14 @@ open class PagingMenuController: UIViewController {
 extension PagingMenuController: UIScrollViewDelegate {
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         onMove?(.didScrollEnd)
+        guard let menuOptions = menuOptions else { return }
         
         let nextPage: Int
-        switch (scrollView, pagingViewController, menuView) {
-        case let (scrollView, pagingViewController?, _) where scrollView.isEqual(pagingViewController.contentScrollView):
+        switch (scrollView, pagingViewController, menuView, menuOptions.isAutoSelectAtScrollEnd) {
+        case let (scrollView, pagingViewController?, _, _) where scrollView.isEqual(pagingViewController.contentScrollView):
             nextPage = nextPageFromCurrentPosition
-        case let (scrollView, _, menuView?) where scrollView.isEqual(menuView):
-            switch menuOptions!.displayMode {
-            case .standard(_, let centerItem, _) where !centerItem: return
-            default: nextPage = nextPageFromCurrentPoint
-            }
+        case let (scrollView, _, menuView?, autoSelect) where scrollView.isEqual(menuView) && autoSelect:
+            nextPage = nextPageFromCurrentPoint
         default: return
         }
         
@@ -334,8 +332,10 @@ extension PagingMenuController: UIScrollViewDelegate {
     }
     
     public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        switch (scrollView, decelerate) {
-        case (let scrollView, false) where scrollView.isEqual(menuView): break
+        guard let menuOptions = menuOptions else { return }
+
+        switch (scrollView, decelerate, menuOptions.isAutoSelectAtScrollEnd) {
+        case (let scrollView, false, true) where scrollView.isEqual(menuView): break
         default: return
         }
         

--- a/Pod/Classes/Protocols/MenuViewCustomizable.swift
+++ b/Pod/Classes/Protocols/MenuViewCustomizable.swift
@@ -15,6 +15,7 @@ public protocol MenuViewCustomizable {
     var animationDuration: TimeInterval { get }
     var deceleratingRate: CGFloat { get }
     var selectedItemCenter: Bool { get }
+    var isAutoSelectAtScrollEnd: Bool { get }
     var displayMode: MenuDisplayMode { get }
     var focusMode: MenuFocusMode { get }
     var dummyItemViewsSet: Int { get }
@@ -40,6 +41,9 @@ public extension MenuViewCustomizable {
         return UIScrollViewDecelerationRateFast
     }
     var selectedItemCenter: Bool {
+        return true
+    }
+    var isAutoSelectAtScrollEnd: Bool {
         return true
     }
     var displayMode: MenuDisplayMode {


### PR DESCRIPTION
Related: https://github.com/kitasuke/PagingMenuController/issues/212

Please see below GIF animation, user is trying to see tab0 (the first tab) by swiping menu. but always back to tab4 by auto select and never see tab0.

Original
![org0](https://cloud.githubusercontent.com/assets/60341/22843598/3461d062-efd2-11e6-8204-cf578e082a51.gif)

I guess most of users don't expect such behaviour on standard mode (and centerItem is false), so I don't make option, just disabled auto-select on the mode. 

Fix
![fix0](https://cloud.githubusercontent.com/assets/60341/22843600/36110a36-efd2-11e6-8eee-f70e42f7703b.gif)

but If you think to need to keep current behaviour, I will add option to keep it.