### PR TITLE
Stop Dancing MenuItems on standard mode

### DIFF
--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -47,6 +47,12 @@ open class MenuView: UIScrollView {
         switch menuOptions.displayMode {
         case .standard(_, let centerItem, _) where centerItem:
             return centerOfScreenWidth
+        case .standard(_, let centerItem, _) where !centerItem:
+            if self.contentView.frame.width < self.frame.width {
+                return contentOffset.x
+            } else {
+                return contentOffsetXForCurrentPage
+            }
         case .segmentedControl:
             return contentOffset.x
         case .infinite:


### PR DESCRIPTION
Maybe related: https://github.com/kitasuke/PagingMenuController/issues/291

That happens if total menu items' width is less than device width.

Original:
![org1](https://cloud.githubusercontent.com/assets/60341/22845025/a24428b8-efd8-11e6-9ae4-aca21aed2ced.gif)

Fix:
![fix1](https://cloud.githubusercontent.com/assets/60341/22845035/a9ed8104-efd8-11e6-854d-1e5e560365df.gif)

