### PR TITLE
Fix for not breaking the animation when moving from position 2 to 0 i…

### DIFF
--- a/Pod/Classes/PagingViewController.swift
+++ b/Pod/Classes/PagingViewController.swift
@@ -204,8 +204,8 @@ open class PagingViewController: UIViewController {
     // MARK: - Internal
     
     internal func relayoutPagingViewControllers() {
-        constructPagingViewControllers()
-        layoutPagingViewControllers()
+//        constructPagingViewControllers()
+//        layoutPagingViewControllers()
         view.setNeedsLayout()
         view.layoutIfNeeded()
     }


### PR DESCRIPTION
When you move from position 2 to 0 the pageview animation breaks, only reach 1 and after that the 0 viewcontroller appears with no animation.

We know the problem happens when you call those two methods but we have not tested with all the cases, so, this pull request is just to let you know this fix the problem on 3 view controllers case.